### PR TITLE
fix(blog): correct article page title

### DIFF
--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -37,15 +37,14 @@ export const generateMetadata = async ({
 		}
 	}
 
-	const title = `${article.title} | Иван Шелепугин`
 	const description = descriptionFromText(article.text)
 	const url = `${HOST}/blog/${article.slug}`
 
 	return {
-		title,
+		title: article.title,
 		description,
 		openGraph: {
-			title,
+			title: article.title,
 			description,
 			type: 'article',
 			images: article.previewUrl,


### PR DESCRIPTION
Substitute title of the article in the page title template.