### PR TITLE
refactor(components): convert timestamp to `Date`

### DIFF
--- a/src/components/ArticlePreview/ArticlePreview.tsx
+++ b/src/components/ArticlePreview/ArticlePreview.tsx
@@ -26,8 +26,8 @@ const ArticlePreview: FC<PropsType> = ({
 	previewUrl,
 	publicationTime,
 }) => {
-	const publicationDateString = new Intl.DateTimeFormat('ru').format(
-		publicationTime,
+	const publicationDateString = new Date(publicationTime).toLocaleDateString(
+		'ru',
 	)
 
 	return (


### PR DESCRIPTION
Convert publication time timestamp to `Date` and use `Date.toLocaleDateString` instead of `Intl.format`.